### PR TITLE
[ENG-1299] Install gettext in CI

### DIFF
--- a/.github/workflows/api-ci-compliance-v2.yml
+++ b/.github/workflows/api-ci-compliance-v2.yml
@@ -30,6 +30,11 @@ jobs:
         python-version: ${{inputs.python_version}}
         cache: poetry
 
+    - name: Install gettext for translations
+      run: |
+        sudo apt-get update
+        sudo apt-get install gettext
+
     - name: Install dependencies
       run: |
         poetry config repositories.nilo-pypi https://us-east1-python.pkg.dev/nilo-devops/python-nilo
@@ -54,6 +59,11 @@ jobs:
         with:
           python-version: ${{inputs.python_version}}
           cache: poetry
+
+      - name: Install gettext for translations
+        run: |
+          sudo apt-get update
+          sudo apt-get install gettext
 
       - name: Install dependencies
         run: |
@@ -90,6 +100,11 @@ jobs:
         with:
           python-version: ${{inputs.python_version}}
           cache: poetry
+
+      - name: Install gettext for translations
+        run: |
+          sudo apt-get update
+          sudo apt-get install gettext
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
gettext is necessary to compile the translations that Django uses

https://docs.djangoproject.com/en/5.0/topics/i18n/#term-localization

https://www.gnu.org/software/gettext/manual/gettext.html


> 🤖 Generated by Code Guardian
# Changelog
## 🚀 Exciting New Features
- Install gettext in ci (https://github.com/nilohealth/.github/commit/c45ee44e1c4c2a65c76c99bab6bfe3978706ed6c by @lucassouto)

