### PR TITLE
[ENG-000] Pin poetry version

### DIFF
--- a/.github/workflows/api-auto-updater.yml
+++ b/.github/workflows/api-auto-updater.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           ref: staging
       - name: Install poetry
-        run: pipx install poetry
+        run: pipx install "poetry==1.8.5"
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/api-ci-compliance-v2.yml
+++ b/.github/workflows/api-ci-compliance-v2.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install poetry
-      run: pipx install poetry
+      run: pipx install "poetry==1.8.5"
 
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install poetry
-        run: pipx install poetry
+        run: pipx install "poetry==1.8.5"
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install poetry
-        run: pipx install poetry
+        run: pipx install "poetry==1.8.5"
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/python-lib-release.yml
+++ b/.github/workflows/python-lib-release.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install poetry
-        run: pipx install poetry
+        run: pipx install "poetry==1.8.5"
       - name: Set up Python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
## Contexto

A versão [2.0.0](https://python-poetry.org/blog/announcing-poetry-2.0.0) do Poetry está quebrando a CI e alteração nas configurações. 

## Problemas

Pretendemos migrar para o uv.

## Solução

Como não há necessidade de nos adequarmos às mudanças da 2.0.0, pinei a versão do poetry para a 1.8.5 (latest v1).


> 🤖 Generated by Code Guardian
# Changelog
## ✏️ Relevant Additional Work
- Pin poetry version (https://github.com/nilohealth/.github/commit/ed4e0addb09335a343e72e910152a8f02511529e by @frnsimoes)

